### PR TITLE
feat: FCM 푸시 알림 서비스 구현 (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 
 # .github
 .github
+
+# FCM Service Account Keys
+**/**-firebase-service-account.json

--- a/customer-service/src/main/resources/application.yml
+++ b/customer-service/src/main/resources/application.yml
@@ -13,3 +13,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+# FCM 설정
+fcm:
+  enabled: true
+  credentials-path: carvana-firebase-service-account.json

--- a/owner-service/src/main/resources/application.yml
+++ b/owner-service/src/main/resources/application.yml
@@ -22,3 +22,8 @@ logging:
     com.carava.carwash: DEBUG
     org.springframework.web: DEBUG
     org.springframework.security: DEBUG
+
+# FCM 설정
+fcm:
+  enabled: true
+  credentials-path: carvana-firebase-service-account.json

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -16,6 +16,7 @@ tasks.getByName<Jar>("jar") {
 }
 
 dependencies {
+    implementation("com.google.firebase:firebase-admin:9.4.2")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")

--- a/shared/src/main/kotlin/com/carava/carwash/common/notification/config/FcmConfig.kt
+++ b/shared/src/main/kotlin/com/carava/carwash/common/notification/config/FcmConfig.kt
@@ -1,0 +1,24 @@
+package com.carava.carwash.common.notification.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * FCM 설정 클래스
+ * application.yml의 fcm 프로퍼티와 매핑됨
+ */
+@ConfigurationProperties(prefix = "fcm")
+data class FcmConfig(
+    /**
+     * FCM 활성화 여부
+     * - true: FCM 초기화 및 푸시 전송
+     * - false: FCM 비활성화 (로컬 개발용)
+     */
+    val enabled: Boolean = true,
+    
+    /**
+     * Firebase 서비스 계정 키 파일 경로
+     * - 기본값: carvana-firebase-service-account.json
+     * - shared/src/main/resources에 위치
+     */
+    val credentialsPath: String = "carvana-firebase-service-account.json"
+)

--- a/shared/src/main/kotlin/com/carava/carwash/common/notification/service/FcmNotificationService.kt
+++ b/shared/src/main/kotlin/com/carava/carwash/common/notification/service/FcmNotificationService.kt
@@ -1,0 +1,112 @@
+package com.carava.carwash.common.notification.service
+
+import com.carava.carwash.common.notification.config.FcmConfig
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.*
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.core.io.ClassPathResource
+import org.springframework.stereotype.Service
+
+@Service
+@EnableConfigurationProperties(FcmConfig::class)
+class FcmNotificationService(
+    private val fcmConfig: FcmConfig
+) : NotificationService {
+    
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    
+    @PostConstruct
+    fun init() {
+        if (!fcmConfig.enabled) {
+            logger.info("FCM 비활성화 상태")
+            return
+        }
+        
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                val resource = ClassPathResource(fcmConfig.credentialsPath)
+                
+                val options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(resource.inputStream))
+                    .build()
+                
+                FirebaseApp.initializeApp(options)
+                logger.info("FCM 초기화 성공")
+            }
+        } catch (e: Exception) {
+            logger.error("FCM 초기화 실패: ${e.message}", e)
+        }
+    }
+    
+    override fun sendPush(token: String, title: String, body: String): Boolean {
+        if (!fcmConfig.enabled) {
+            logger.debug("FCM 비활성화 - 푸시 전송 스킵")
+            return true
+        }
+        
+        val message = Message.builder()
+            .setToken(token)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build()
+            )
+            .build()
+        
+        return try {
+            val messageId = FirebaseMessaging.getInstance().send(message)
+            logger.info("푸시 전송 성공: $messageId")
+            true
+        } catch (e: Exception) {
+            logger.error("푸시 전송 실패: ${e.message}", e)
+            false
+        }
+    }
+    
+    override fun sendToTopic(topic: String, title: String, body: String): Boolean {
+        if (!fcmConfig.enabled) {
+            logger.debug("FCM 비활성화 - 토픽 전송 스킵")
+            return true
+        }
+        
+        val message = Message.builder()
+            .setTopic(topic)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build()
+            )
+            .build()
+        
+        return try {
+            val messageId = FirebaseMessaging.getInstance().send(message)
+            logger.info("토픽 메시지 전송 성공 - Topic: $topic, MessageId: $messageId")
+            true
+        } catch (e: Exception) {
+            logger.error("토픽 메시지 전송 실패 - Topic: $topic, Error: ${e.message}", e)
+            false
+        }
+    }
+    
+    override fun subscribeToTopic(token: String, topic: String): Boolean {
+        if (!fcmConfig.enabled) {
+            logger.debug("FCM 비활성화 - 토픽 구독 스킵")
+            return true
+        }
+        
+        return try {
+            FirebaseMessaging.getInstance().subscribeToTopic(listOf(token), topic)
+            logger.info("토픽 구독 성공 - Topic: $topic")
+            true
+        } catch (e: Exception) {
+            logger.error("토픽 구독 실패 - Topic: $topic, Error: ${e.message}", e)
+            false
+        }
+    }
+}

--- a/shared/src/main/kotlin/com/carava/carwash/common/notification/service/NotificationService.kt
+++ b/shared/src/main/kotlin/com/carava/carwash/common/notification/service/NotificationService.kt
@@ -1,0 +1,33 @@
+package com.carava.carwash.common.notification.service
+
+/**
+ * 알림 서비스 인터페이스
+ * FCM, Email, SMS 등 다양한 채널로 확장 가능
+ */
+interface NotificationService {
+    /**
+     * 개별 기기에 푸시 알림 전송
+     * @param token FCM 토큰
+     * @param title 알림 제목
+     * @param body 알림 내용
+     * @return 전송 성공 여부
+     */
+    fun sendPush(token: String, title: String, body: String): Boolean
+    
+    /**
+     * 특정 토픽에 푸시 알림 전송
+     * @param topic 토픽 이름
+     * @param title 알림 제목
+     * @param body 알림 내용
+     * @return 전송 성공 여부
+     */
+    fun sendToTopic(topic: String, title: String, body: String): Boolean
+    
+    /**
+     * 토픽 구독
+     * @param token FCM 토큰
+     * @param topic 구독할 토픽 이름
+     * @return 구독 성공 여부
+     */
+    fun subscribeToTopic(token: String, topic: String): Boolean
+}


### PR DESCRIPTION
- shared 모듈에 notification 패키지 구조 설계
- FcmConfig 설정 클래스 추가 (application.yml 매핑)
- NotificationService 인터페이스 정의
- FcmNotificationService 구현체 작성
  - 개별 푸시 알림 전송
  - 토픽 기반 알림 전송
  - 토픽 구독 기능
- Firebase Admin SDK 의존성 추가 (build.gradle.kts)
- 각 서비스 application.yml에 FCM 설정 추가
- .gitignore에 FCM 키 파일 패턴 추가

환경별 FCM 활성화/비활성화 가능
- local: FCM 비활성화 (enabled: false)
- dev/prod: FCM 활성화 (enabled: true)

주의: FCM 서비스 계정 키는 별도로 관리 필요

close: #8 